### PR TITLE
Config externe

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ L'idée consiste donc à remonter ces informations (emploi du temps, note, devoi
 
 Je mets donc à disposition un script python [pronote.py](pronote.py).  
 Ce script permet de se connecter à Pronote et récupère toutes les informations dans un JSON.  
-Il est initialisé avec le compte de demo de Pronote > reste à l'adapter à vos identifiants en changeant les variables au début du script.   
-Il faut donc installer ce script dans un dossier (nommé par exemple "python_script") dans le dossier /config de votre HA.  
+Ce script utilise un fichier de configuration [config.ini] qui est initialisé avec le compte de demo de Pronote > reste à l'adapter à vos identifiants en changeant les variables dans la section defaut.   
+Il faut donc installer ce script ainsi que le fichier de configuration dans un dossier (nommé par exemple "python_script") dans le dossier /config de votre HA.  
 Ce script quand il est lancé génère un fichier pronote_AAAA.json qu'il dépose dans /config/www/ de votre HA.  
-NB : AAAA est le nom de l'élève à paramétré dans le script.  
+NB : AAAA est le nom de l'élève à paramétré dans le fichier de configuration.  
 Il doit ensuite être lancé de façon régulière - toute les 5 ou 10 minutes - via la crontab par exemple.  
 Exemple : */10 * * * * /usr/bin/python3 /usr/share/hassio/homeassistant/python_scripts/pronote.py > /tmp/pronote.log 2>&1  
 

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,16 @@
+[defaut]
+#prénom de votre enfant par exemple - ne sert que pour le nom du fichier json - pas d'espace - pas d'accent !! 
+eleve_id = demo
+#NOM Prénom de votre enfant - sert quand on se connecte avec un compte parent qui a plusieurs enfants !
+eleve_nom_prenom = PARENT Fanny
+# sert au prefix de l'url https://PREFIX.index-education.net/pronote/
+prefix_url = demo
+#eleve ou parent - si vous utlisez un compte parent ou eleve pour vous connecter 
+type_compte = eleve
+#utlisateur pronote  - a remplacer par le nom d'utilisateur pronote de l'élève ou du parent si type_compte=parent
+username = demonstration 
+# mot de passe pronote - a remplacer par le mot de passe du compte de l'élève ou du parent si type_compte=parent
+password = pronotevs
+#A initialiser si connexion via ENT - avec le nom technique de l'ENT - exemple : ent=paris_classe_numerique
+ent = None
+

--- a/config.ini
+++ b/config.ini
@@ -1,15 +1,15 @@
 [defaut]
-#prénom de votre enfant par exemple - ne sert que pour le nom du fichier json - pas d'espace - pas d'accent !! 
+#prÃ©nom de votre enfant par exemple - ne sert que pour le nom du fichier json - pas d'espace - pas d'accent !! 
 eleve_id = demo
-#NOM Prénom de votre enfant - sert quand on se connecte avec un compte parent qui a plusieurs enfants !
+#NOM PrÃ©nom de votre enfant - sert quand on se connecte avec un compte parent qui a plusieurs enfants !
 eleve_nom_prenom = PARENT Fanny
 # sert au prefix de l'url https://PREFIX.index-education.net/pronote/
 prefix_url = demo
 #eleve ou parent - si vous utlisez un compte parent ou eleve pour vous connecter 
 type_compte = eleve
-#utlisateur pronote  - a remplacer par le nom d'utilisateur pronote de l'élève ou du parent si type_compte=parent
+#utlisateur pronote  - a remplacer par le nom d'utilisateur pronote de l'Ã©lÃ¨ve ou du parent si type_compte=parent
 username = demonstration 
-# mot de passe pronote - a remplacer par le mot de passe du compte de l'élève ou du parent si type_compte=parent
+# mot de passe pronote - a remplacer par le mot de passe du compte de l'Ã©lÃ¨ve ou du parent si type_compte=parent
 password = pronotevs
 #A initialiser si connexion via ENT - avec le nom technique de l'ENT - exemple : ent=paris_classe_numerique
 ent = None

--- a/pronote.py
+++ b/pronote.py
@@ -323,7 +323,7 @@ if client.logged_in:
 
     #Stockage dans un fichier json : edt + notes + devoirs 
     location = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
-    with open(os.path.join(location, ".\pronote_"+eleve_id+".json"), "a") as outfile:
+    with open(os.path.join(location, "../www/pronote_"+eleve_id+".json"), "a") as outfile:
         outfile.truncate(0)
         json.dump(jsondata, outfile, indent=4)
     

--- a/pronote.py
+++ b/pronote.py
@@ -17,22 +17,47 @@ import sys
 from datetime import date
 from datetime import timedelta 
 import json
+import configparser
 
-#Variables a remplacer (ou laisser comme ça pour tester la démo)
-eleve_id="demo" #prénom de votre enfant par exemple - ne sert que pour le nom du fichier json - pas d'espace - pas d'accent !! 
-eleve_nom_prenom = "PARENT Fanny" #NOM Prénom de votre enfant - sert quand on se connecte avec un compte parent qui a plusieurs enfants !
-prefix_url = "demo" # sert au prefix de l'url https://PREFIX.index-education.net/pronote/
-type_compte = "eleve" #eleve ou parent - si vous utlisez un compte parent ou eleve pour vous connecter 
-username="demonstration" #utlisateur pronote  - a remplacer par le nom d'utilisateur pronote de l'élève ou du parent si type_compte=parent
-password="pronotevs" # mot de passe pronote - a remplacer par le mot de passe du compte de l'élève ou du parent si type_compte=parent
-ent = None #A initialiser si connexion via ENT - avec le nom technique de l'ENT - exemple : ent=paris_classe_numerique
+config = configparser.ConfigParser()
+config.read("config.ini")
+
+section="defaut"
+eleve_id = config.get(section, "eleve_id")
+eleve_nom_prenom = config.get(section, "eleve_nom_prenom")
+prefix_url = config.get(section, "prefix_url")
+type_compte = config.get(section, "type_compte")
+username = config.get(section, "username")
+password = config.get(section, "password")
+ent = config.get(section, "ent")
+
+if ent == "ac_lyon":
+        ent = ac_lyon
+elif ent == "ac_grenoble":
+        ent = ac_grenoble
+elif ent == "ac_orleans_tours":
+        ent = ac_orleans_tours
+elif ent == "ac_reims":
+        ent = ac_reims
+elif ent == "ac_reunion":
+        ent = ac_reunion
+elif ent == "atrium_sud":
+        ent = atrium_sud
+elif ent == "ile_de_france":
+        ent = ile_de_france
+elif ent == "monbureaunumerique":
+        ent = monbureaunumerique
+elif ent == "occitanie_montpellier":
+        ent = occitanie_montpellier
+elif ent == "paris_classe_numerique":
+        ent = paris_classe_numerique
+else:
+        ent = None
 
 #Autres de configuration
 index_note=0 #debut de la boucle des notes
 limit_note=11 #nombre max de note à afficher + 1 
 longmax_devoir = 125 #nombre de caractère max dans la description des devoirs
-
-
 
 #Connection à Pronote avec ou sans ENT
 if ent:
@@ -239,7 +264,7 @@ if client.logged_in:
     #Récupération  des absences pour l'année
     #absences = [period.absences for period in client.periods]
     #Récupération  des absences pour la période en cours 
-    absences = client.current_period.absences()
+    absences = client.current_period.absences
     absences = sorted(absences, key=lambda absence: absence.from_date, reverse=True)
 
 
@@ -292,13 +317,13 @@ if client.logged_in:
         jsondata['evaluation'].append(jsondata['acquisition'])        
 
     
-    print(json.dumps(jsondata['evaluation'], indent=4))
+    #print(json.dumps(jsondata['evaluation'], indent=4))
 
 
 
     #Stockage dans un fichier json : edt + notes + devoirs 
     location = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
-    with open(os.path.join(location, "../www/pronote_"+eleve_id+".json"), "a") as outfile:
+    with open(os.path.join(location, ".\pronote_"+eleve_id+".json"), "a") as outfile:
         outfile.truncate(0)
         json.dump(jsondata, outfile, indent=4)
     


### PR DESCRIPTION
Externalisation de la configuration : plus besoin d'éditer le fichier python pour adapter à ses enfants.
La deuxième étape sera de rajouter une option type "-e enfant1" pour aller chercher la configuration dans la section "[enfant1]".